### PR TITLE
Allow to adjust client token permissions

### DIFF
--- a/nvgrid/README.rst
+++ b/nvgrid/README.rst
@@ -18,6 +18,10 @@ DIB_NVGRID_CLIENT_TOKEN_URL. Set it to the file path on the local filesystem or
 to remote URL and it will be copied to /etc/nvidia/ClientConfigToken/ inside
 the image.
 
+DIB_NVGRID_CLIENT_TOKEN_MODE - defines mode that will be set for client token
+file inside the image. Some versions of GRID require it to be readable for
+all users.
+
 To override hosts records we have two options. The first one is to set
 DIB_NVGRID_HOSTS_FILE which defines path to the text file. It's content will be
 added to /etc/hosts on the image as is. The second one is a env VAR DIB_HOSTS_ADD

--- a/nvgrid/extra-data.d/99-copy-files
+++ b/nvgrid/extra-data.d/99-copy-files
@@ -71,6 +71,9 @@ else
         $TMP_MOUNT_PATH/etc/nvidia/ClientConfigToken/
 fi
 
+# Change token permissions if needed
+sudo chmod ${DIB_NVGRID_CLIENT_TOKEN_MODE:-'0400'} $TMP_MOUNT_PATH/etc/nvidia/ClientConfigToken/*
+
 # Copy driver to VM either from URL or from File
 if [ -z "${DIB_NVGRID_DRIVER_URL:-}" ]; then
     if [ -z "${DIB_NVGRID_DRIVER_FILE:-}" ]; then


### PR DESCRIPTION
Newer versions of GRID driver fail if token persmissions are set
to 0400, and require all users to be able to read a client token.

With that we allow to pass mode for client token file, that will
be set to passed value during image build process.