### PR TITLE
Add install-systemd element that isntalls resolved

### DIFF
--- a/install-systemd-resolved/README.rst
+++ b/install-systemd-resolved/README.rst
@@ -1,0 +1,6 @@
+================
+Systemd Resolved
+================
+
+This is a simple element that ensures that systemd and systemd-resolved are
+installed on the system.

--- a/install-systemd-resolved/element-deps
+++ b/install-systemd-resolved/element-deps
@@ -1,0 +1,1 @@
+package-installs

--- a/install-systemd-resolved/package-installs.yaml
+++ b/install-systemd-resolved/package-installs.yaml
@@ -1,0 +1,2 @@
+systemd-sysv:
+systemd-resolved:


### PR DESCRIPTION
Plain Debian 12 image comes without systemd-resolved while expects
it to be installed. So we add a custom element that will handle such
installation.