### PR TITLE
Add hook around systemd-resolved installation

### DIFF
--- a/install-systemd-resolved/cleanup.d/30-cleanup-resolved-mimic
+++ b/install-systemd-resolved/cleanup.d/30-cleanup-resolved-mimic
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm ${TARGET_ROOT}/run/systemd/resolve/stub-resolv.conf
+rmdir ${TARGET_ROOT}/run/systemd/resolve/

--- a/install-systemd-resolved/pre-install.d/05-preserve-nameservers
+++ b/install-systemd-resolved/pre-install.d/05-preserve-nameservers
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p /run/systemd/resolve
+echo "Saving /etc/resolve.conf to mimic systemd-resolved until in chroot"
+cat /etc/resolv.conf > /run/systemd/resolve/stub-resolv.conf


### PR DESCRIPTION
Once systemd-resolved is installed, it replaces /etc/resolv.conf with
a symlink to /run, where resolved is supposed to place resulting
configuration.

However, it is not possible to startup a service inside chroot
environment. So, we workaround that by preserving resolv.conf
content in destination file for resolved before it is installed.