### PR TITLE
Fork fedora element to the repo

### DIFF
--- a/bugfix-fedora/README.rst
+++ b/bugfix-fedora/README.rst
@@ -1,0 +1,30 @@
+======
+fedora
+======
+
+Use Fedora cloud images as the baseline for built disk images. For further
+details see the redhat-common README.
+
+Releases
+--------
+
+This element targets the current and previous version of Fedora; these
+values clearly changes over time.  To fix the version set the
+`DIB_RELEASE` variable to the Fedora version (e.g. ``36``).  The
+default value is the current best supported version (i.e. it may
+change upward at any given release to support the next Fedora).
+
+
+Environment Variables
+---------------------
+
+DIB_DISTRIBUTION_MIRROR:
+   :Required: No
+   :Default: None
+   :Description: To use a Fedora Yum mirror, set this variable to the mirror URL
+                 before running bin/disk-image-create. This URL should point to
+                 the directory containing the ``releases/updates/development``
+                 and ``extras`` directories.
+   :Example: ``DIB\_DISTRIBUTION\_MIRROR=http://download.fedoraproject.org/pub/fedora/linux``
+
+

--- a/bugfix-fedora/element-deps
+++ b/bugfix-fedora/element-deps
@@ -1,0 +1,6 @@
+cache-url
+dkms
+redhat-common
+rpm-distro
+source-repositories
+yum

--- a/bugfix-fedora/element-provides
+++ b/bugfix-fedora/element-provides
@@ -1,0 +1,1 @@
+operating-system

--- a/bugfix-fedora/environment.d/10-fedora-distro-name.bash
+++ b/bugfix-fedora/environment.d/10-fedora-distro-name.bash
@@ -1,0 +1,4 @@
+export DISTRO_NAME=fedora
+export DIB_RELEASE=${DIB_RELEASE:-37}
+export EFI_BOOT_DIR="EFI/fedora"
+

--- a/bugfix-fedora/environment.d/11-yum-dnf.bash
+++ b/bugfix-fedora/environment.d/11-yum-dnf.bash
@@ -1,0 +1,8 @@
+# since f22, dnf is the yum replacement.  Mostly it drops in
+# unmodified, so while we transition KISS and use this to choose
+
+if [ $DIB_RELEASE -ge 22 ]; then
+    export YUM=dnf
+else
+    export YUM=yum
+fi

--- a/bugfix-fedora/package-installs.yaml
+++ b/bugfix-fedora/package-installs.yaml
@@ -1,0 +1,34 @@
+# On a fresh Fedora 18 install you might have to update audit in order to
+# fix a conflict with a file from the glibc package.
+# https://bugzilla.redhat.com/show_bug.cgi?id=894307
+audit:
+
+# The version of openssl shipped in the fedora cloud image is no longer
+# compatible with new python environments installed by virtualenv, so we need
+# to update it first.
+# See https://bugs.launchpad.net/diskimage-builder/+bug/1254879
+openssl:
+
+# FIXME: To avoid conflict between the pyOpenSSL installed via python-pip
+# and pyOpenSSL installed via yum, we are going to sort it out installing
+# it earlier at the beginning of the image building process. Python-pip
+# is installing pyOpenSSL as part of satisfying the requirements.txt
+# in python-glanceclient and afterwards yum tries to install it as a
+# dependency of the python-paste package needed for the heat element,
+# this seems to be conflicting and causing the image building process to
+# fail. The problem is happening on a Fedora 18 system.
+pyOpenSSL:
+
+# Workaround for:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1066983
+vim-minimal:
+
+# kernel modules to match the core kernel
+# Newer Fedora 21 splits these out into a separate package.
+# It contains iscsi_tcp.ko (for Ironic) among other things like network
+# driver modules, etc.
+kernel-modules:
+
+# This small package is required on Fedora 21 in order to build some
+# packages via source (MySQL driver).
+redhat-rpm-config:

--- a/bugfix-fedora/pre-install.d/00-02-set-fedora-mirror
+++ b/bugfix-fedora/pre-install.d/00-02-set-fedora-mirror
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+DIB_DISTRIBUTION_MIRROR=${DIB_DISTRIBUTION_MIRROR:-}
+
+[ -n "$DIB_DISTRIBUTION_MIRROR" ] || exit 0
+
+if [[ ${DIB_RELEASE} -gt 27 ]]; then
+    # urgh, the repo is wrong in the "baseurl" line, see
+    #  https://pagure.io/fedora/repos/issue/70
+    for FILE in /etc/yum.repos.d/fedora-updates.repo /etc/yum.repos.d/fedora-updates-testing.repo; do
+        sed -i "s,/os/,," $FILE
+    done
+fi
+
+for FILE in /etc/yum.repos.d/fedora.repo /etc/yum.repos.d/fedora-updates.repo /etc/yum.repos.d/fedora-updates-testing.repo; do
+    # In >=32 this became "download.example" not
+    # "download.fedoraproject.org"
+    cat $FILE
+    sudo sed -e "s,^#baseurl=http[s]*://download.\(fedoraproject.org\|example\)/pub/fedora/linux,baseurl=$DIB_DISTRIBUTION_MIRROR,;/^metalink/d" -i $FILE
+    cat $FILE
+done

--- a/bugfix-fedora/pre-install.d/02-set-machine-id
+++ b/bugfix-fedora/pre-install.d/02-set-machine-id
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+# The systemd .spec file does this in %post [1] and it turns out that
+# (in what is possibly a bug [2]) that kernel install requires
+# /etc/machine-id.  This affects "fedora" (the image-based build) if
+# there is no systemd update to install ... with "fedora-minimal" we
+# are always installing into the chroot so, so %post always runs and
+# this is always run
+#
+# [1] https://src.fedoraproject.org/rpms/systemd/blob/master/f/systemd.spec
+# [2] https://bugzilla.redhat.com/show_bug.cgi?id=1486124
+
+systemd-machine-id-setup

--- a/bugfix-fedora/root.d/10-fedora-cloud-image
+++ b/bugfix-fedora/root.d/10-fedora-cloud-image
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+[ -n "$ARCH" ]
+[ -n "$TARGET_ROOT" ]
+
+if [ 'amd64' = "$ARCH" ] ; then
+    ARCH="x86_64"
+fi
+if [[ "${ARCH}" == "arm64" ]]; then
+    ARCH="aarch64"
+fi
+
+DIB_LOCAL_IMAGE=${DIB_LOCAL_IMAGE:-""}
+
+if [ -n "$DIB_LOCAL_IMAGE" ]; then
+    IMAGE_LOCATION=$DIB_LOCAL_IMAGE
+    # No need to copy a local image into the cache directory, so just specify
+    # the cached path as the original path.
+    CACHED_IMAGE=$IMAGE_LOCATION
+    BASE_IMAGE_FILE=`basename $DIB_LOCAL_IMAGE`
+    BASE_IMAGE_TAR=$BASE_IMAGE_FILE.tgz
+else
+    # note default DIB_RELEASE set in environment setup
+    case ${ARCH} in
+    x86_64|aarch64)
+        if [[ ${DIB_RELEASE} -ge 37 ]]; then
+            DIB_CLOUD_IMAGES=${DIB_CLOUD_IMAGES:-https://download.fedoraproject.org/pub/fedora/linux/releases/${DIB_RELEASE}/Cloud/${ARCH}/images}
+        elif [[ ${DIB_RELEASE} -ge 28 ]] && [[ ${DIB_RELEASE} -le 36 ]]; then
+            DIB_CLOUD_IMAGES=${DIB_CLOUD_IMAGES:-https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/${DIB_RELEASE}/Cloud/${ARCH}/images}
+        else
+            DIB_CLOUD_IMAGES=${DIB_CLOUD_IMAGES:-https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/${DIB_RELEASE}/CloudImages/${ARCH}/images}
+        fi
+        ;;
+    ppc64|ppc64le)
+        if [[ ${DIB_RELEASE} -ge 37 ]]; then
+            DIB_CLOUD_IMAGES=${DIB_CLOUD_IMAGES:-https://dl.fedoraproject.org/pub/fedora-secondary/releases/${DIB_RELEASE}/Cloud/${ARCH}/images}
+        elif [[ ${DIB_RELEASE} -ge 28 ]] && [[ ${DIB_RELEASE} -le 36 ]]; then
+            DIB_CLOUD_IMAGES=${DIB_CLOUD_IMAGES:-http://archives.fedoraproject.org/pub/archive/fedora-secondary/releases/${DIB_RELEASE}/Cloud/${ARCH}/images}
+        else
+            DIB_CLOUD_IMAGES=${DIB_CLOUD_IMAGES:-http://archives.fedoraproject.org/pub/archive/fedora-secondary/releases/${DIB_RELEASE}/CloudImages/${ARCH}/images}
+        fi
+        ;;
+    *)
+        echo "Error: unknown ARCH: ${ARCH}"
+        exit 1
+        ;;
+    esac
+    # We have curl write headers to stderr so that we can debug fedora
+    # mirror locations that don't have valid subreleases in their paths.
+    if [[ ${DIB_RELEASE} -ge 40 ]]; then
+        SUBRELEASE_REGEXP=${SUBRELEASE_REGEXP:-'(?<=Fedora-Cloud-Base-Generic\.'${ARCH}'-'${DIB_RELEASE}'-).*?(?=\.qcow2)'}
+        SUBRELEASE=$(head -1 < <(curl -Lis -D /dev/stderr $DIB_CLOUD_IMAGES/ | grep -o -P $SUBRELEASE_REGEXP | sort -r))
+        BASE_IMAGE_FILE=${BASE_IMAGE_FILE:-Fedora-Cloud-Base-Generic.$ARCH-$DIB_RELEASE-$SUBRELEASE.qcow2}
+        BASE_IMAGE_TAR=Fedora-Cloud-Base-Generic.$ARCH-$DIB_RELEASE-$SUBRELEASE.tgz
+    else
+        SUBRELEASE_REGEXP=${SUBRELEASE_REGEXP:-'(?<=Fedora-Cloud-Base-'${DIB_RELEASE}'-).*?(?=.'${ARCH}'.qcow2)'}
+        SUBRELEASE=$(head -1 < <(curl -Lis -D /dev/stderr $DIB_CLOUD_IMAGES/ | grep -o -P $SUBRELEASE_REGEXP | sort -r))
+        BASE_IMAGE_FILE=${BASE_IMAGE_FILE:-Fedora-Cloud-Base-$DIB_RELEASE-$SUBRELEASE.$ARCH.qcow2}
+        BASE_IMAGE_TAR=Fedora-Cloud-Base-$DIB_RELEASE-$SUBRELEASE.$ARCH.tgz
+    fi
+
+    IMAGE_LOCATION=$DIB_CLOUD_IMAGES/$BASE_IMAGE_FILE
+    CACHED_IMAGE=$DIB_IMAGE_CACHE/$BASE_IMAGE_FILE
+fi
+
+$TMP_HOOKS_PATH/bin/extract-image $BASE_IMAGE_FILE $BASE_IMAGE_TAR $IMAGE_LOCATION $CACHED_IMAGE

--- a/bugfix-fedora/test-elements/build-succeeds/element-deps
+++ b/bugfix-fedora/test-elements/build-succeeds/element-deps
@@ -1,0 +1,2 @@
+base
+openstack-ci-mirrors


### PR DESCRIPTION
This adds bugfixed `fedora` element version to build from Cloud image
which implements fixes from this series ofchanges [1]

The ultimate goal is to be able to leverage fixes before they're getting
available through new DIB release.

[1] https://review.opendev.org/c/openstack/diskimage-builder/+/922109