### PR TITLE
Skip auditd update for Fedora 39

### DIFF
--- a/bugfix-fedora/install.d/00-01-hold-audit
+++ b/bugfix-fedora/install.d/00-01-hold-audit
@@ -1,0 +1,4 @@
+if [[ ${DIB_RELEASE} -eq 39 ]]; then
+    install-packages python3-dnf-plugin-versionlock
+    dnf versionlock add audit
+fi

--- a/bugfix-fedora/install.d/99-01-hold-audit
+++ b/bugfix-fedora/install.d/99-01-hold-audit
@@ -1,0 +1,3 @@
+if [[ ${DIB_RELEASE} -eq 39 ]]; then
+    dnf versionlock delete audit
+fi


### PR DESCRIPTION
During package upgrade for Fedora 39 audit fails scriptlet error on
prior version removal with:
error: %preun(audit-3.1.2-4.fc39.x86_64) scriptlet failed, exit status 2

So we hold the package explicitly to skip the issue during image build.