### PR TITLE
Fix Fedora 41

### DIFF
--- a/bugfix-fedora/root.d/10-fedora-cloud-image
+++ b/bugfix-fedora/root.d/10-fedora-cloud-image
@@ -53,7 +53,12 @@ else
     esac
     # We have curl write headers to stderr so that we can debug fedora
     # mirror locations that don't have valid subreleases in their paths.
-    if [[ ${DIB_RELEASE} -ge 40 ]]; then
+    if [[ ${DIB_RELEASE} -ge 41 ]]; then
+        SUBRELEASE_REGEXP=${SUBRELEASE_REGEXP:-'(?<=Fedora-Cloud-Base-Generic-'${DIB_RELEASE}'-).*?(?=\.'${ARCH}'\.qcow2)'}
+        SUBRELEASE=$(head -1 < <(curl -Lis -D /dev/stderr $DIB_CLOUD_IMAGES/ | grep -o -P $SUBRELEASE_REGEXP | sort -r))
+        BASE_IMAGE_FILE=${BASE_IMAGE_FILE:-Fedora-Cloud-Base-Generic-$DIB_RELEASE-$SUBRELEASE.$ARCH.qcow2}
+        BASE_IMAGE_TAR=Fedora-Cloud-Base-Generic-$DIB_RELEASE-$SUBRELEASE.$ARCH.tgz
+    elif [[ ${DIB_RELEASE} -eq 40 ]]; then
         SUBRELEASE_REGEXP=${SUBRELEASE_REGEXP:-'(?<=Fedora-Cloud-Base-Generic\.'${ARCH}'-'${DIB_RELEASE}'-).*?(?=\.qcow2)'}
         SUBRELEASE=$(head -1 < <(curl -Lis -D /dev/stderr $DIB_CLOUD_IMAGES/ | grep -o -P $SUBRELEASE_REGEXP | sort -r))
         BASE_IMAGE_FILE=${BASE_IMAGE_FILE:-Fedora-Cloud-Base-Generic.$ARCH-$DIB_RELEASE-$SUBRELEASE.qcow2}


### PR DESCRIPTION
Fedora 41 has changed the image naming format again. We need to use
correct one.