### PR TITLE
Fix deprecated flag for dnf5

### DIFF
--- a/yum/bin/install-packages
+++ b/yum/bin/install-packages
@@ -26,7 +26,7 @@ MAP_ELEMENT=
 
 # allow override for dnf, as shipped by default with >=F22
 YUM=${YUM:-yum}
-YUM_FLAGS=${YUM_FLAGS:--y -d}
+YUM_FLAGS=${YUM_FLAGS:--y -v}
 
 # save global xtrace state
 _xtrace=$(set +o | grep xtrace)
@@ -136,10 +136,10 @@ if [ -n "$WHITELIST" ]; then
     # [1] https://bugzilla.redhat.com/show_bug.cgi?id=965567
     set -o xtrace
 
-    DNF5=$(which dnf5 2>/dev/null)
+    DNF5=$(which dnf5 2>/dev/null || true)
     if [ ${YUM} == 'dnf' ] && [ -n "$DNF5" ]; then
         # dnf5 does not support debug flag
-        YUM_FLAGS=${YUM_FLAGS//-d}
+        YUM_FLAGS=${YUM_FLAGS//-v}
     fi
 
     ${YUM} $YUM_FLAGS $ACTION $EXTRA_ARGS $PKGS


### PR DESCRIPTION
Previously it was attempted to replace `-d` flag, while in fact the one
which was deprecated was `-v`. This follow-up fixes behaviour for
building images prior to Fedora 41.